### PR TITLE
missing pthread include

### DIFF
--- a/src/device/device_common.h
+++ b/src/device/device_common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <pthread.h>
 
 typedef enum {
     // libmonome devices


### PR DESCRIPTION
`gcc` is smart enough to include it implicitely for the use of `pthread_t` just bellow but `musl-gcc` (under alpine) is not as smart.